### PR TITLE
Fix column calculation for game layout

### DIFF
--- a/src/core/useGame.ts
+++ b/src/core/useGame.ts
@@ -163,7 +163,7 @@ export function useGame(config: GameConfig): Game {
         while (indexSet.has(i))
           i = floor(random(0, (index + 1) ** 2))
         const row = floor(i / (index + 1))
-        const column = index ? i % index : 0
+        const column = i % (index + 1)
         const node: CardNode = {
           id: `${index}-${i}`,
           type: k,


### PR DESCRIPTION
### Motivation
- The grid layout used `const column = index ? i % index : 0`, which computes incorrect column indices for floors with more than one column and can collapse/overlap nodes on higher layers.
- The modulus should be based on the number of columns on the floor, which is `(index + 1)`, not `index`.
- Correcting this ensures nodes are distributed across columns properly and fixes layout glitches during game initialization.

### Description
- Replaced `const column = index ? i % index : 0` with `const column = i % (index + 1)` in `src/core/useGame.ts`.
- Updated node positioning so the computed `column` is used to calculate `left` coordinates consistently across floors.
- The change is localized to a single-line arithmetic fix and does not alter other game logic.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f54d336c88330b492afdcdafb6630)